### PR TITLE
Update api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,12 +51,13 @@ export const importSchema = async (
   faunadbKey: string,
   schema: string,
   mode: 'replace' | 'merge' | 'override' = 'replace',
+  endpoint: string = 'https://graphql.fauna.com'
 ): Promise<string> => {
   try {
     let params = `?mode=${mode}`
 
     const response = await got.post(
-      `https://graphql.fauna.com/import${params}`,
+      `${endpoint}/import${params}`,
       {
         body: schema,
         headers: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,8 +53,7 @@ export const importSchema = async (
   mode: 'replace' | 'merge' | 'override' = 'replace',
 ): Promise<string> => {
   try {
-    let params = ''
-    if (mode === 'override') params = '?mode=override'
+    let params = `?mode=${mode}`
 
     const response = await got.post(
       `https://graphql.fauna.com/import${params}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export const makeSchema = (typeDefs: string[]): string => {
 export const importSchema = async (
   faunadbKey: string,
   schema: string,
-  mode: 'merge' | 'override' = 'merge'
+  mode: 'replace' | 'merge' | 'override' = 'replace',
 ): Promise<string> => {
   try {
     let params = ''


### PR DESCRIPTION
Fauna has added a `replace` mode to imports.  The endpoint also needs to be configurable to connect to Region Groups or even local instances.